### PR TITLE
resolving various issues with kubeadm init bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,15 +83,20 @@ RUN apt-get update
 
 # Install packages from those sources:
 RUN apt-get install -y \
+    docker-ce=${VERSION_DOCK}~ce-0~ubuntu-xenial \
     ebtables \
     ethtool \
-    docker-ce=${VERSION_DOCK}~ce-0~ubuntu-xenial \
     kmod \
     kubernetes-cni \
     libwrap0 \
     socat \
     systemd \
     tcpd
+
+# Install libgcrypt11 for CentOS support:
+RUN curl -o /tmp/libgcrypt11_1.5.3.deb -L https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/8993248/+files/libgcrypt11_1.5.3-2ubuntu4.3_amd64.deb ;\
+    dpkg -i /tmp/libgcrypt11_1.5.3.deb ;\
+    apt-get install -f
 
 # Clean up apt-cache:
 RUN apt-get clean ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,6 @@ RUN apt-get install -y \
     kmod \
     kubernetes-cni \
     libwrap0 \
-    socat \
     systemd \
     tcpd
 
@@ -97,6 +96,10 @@ RUN apt-get install -y \
 RUN curl -o /tmp/libgcrypt11_1.5.3.deb -L https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/8993248/+files/libgcrypt11_1.5.3-2ubuntu4.3_amd64.deb ;\
     dpkg -i /tmp/libgcrypt11_1.5.3.deb ;\
     apt-get install -f
+
+# Separately install any kubeadm requirements:
+RUN apt-get install -y \
+    socat
 
 # Clean up apt-cache:
 RUN apt-get clean ;\

--- a/bin/distro/centos/start
+++ b/bin/distro/centos/start
@@ -46,6 +46,7 @@ then
     echo "User "${USER}" will NOT be added to the docker group on ${HOSTNAME}"
 else
     echo "Adding user "${USER}" to docker group on ${HOSTNAME}:"
+    sudo usermod -aG docker ${USER}
 fi
 
 echo "COMPLETE!"

--- a/bin/distro/centos/start
+++ b/bin/distro/centos/start
@@ -1,21 +1,7 @@
 #!/bin/bash
 
 export DOCKER_VERSION="17.03.2"
-
-### Declare colors to use during the running of this script:
-declare -r GREEN="\033[0;32m"
-declare -r RED="\033[0;31m"
-declare -r YELLOW="\033[0;33m"
-
-function echo_green {
-  echo -e "${GREEN}$1"; tput sgr0
-}
-function echo_red {
-  echo -e "${RED}$1"; tput sgr0
-}
-function echo_yellow {
-  echo -e "${YELLOW}$1"; tput sgr0
-}
+export DOCKER_PRVUSER="true"
 
 sudo yum upgrade -y
 
@@ -53,3 +39,13 @@ sudo yum install -y --setopt=obsoletes=0 \
 sudo systemctl start docker
 
 sudo systemctl enable docker
+
+# Adding current ${USER} to docker group:
+if [ ${DOCKER_PRVUSER} != "true" ]
+then
+    echo "User "${USER}" will NOT be added to the docker group on ${HOSTNAME}"
+else
+    echo "Adding user "${USER}" to docker group on ${HOSTNAME}:"
+fi
+
+echo "COMPLETE!"

--- a/bin/distro/ubuntu/start
+++ b/bin/distro/ubuntu/start
@@ -35,6 +35,7 @@ then
     echo "User "${USER}" will NOT be added to the docker group on ${HOSTNAME}"
 else
     echo "Adding user "${USER}" to docker group on ${HOSTNAME}:"
+    sudo usermod -aG docker ${USER}
 fi
 
 echo "COMPLETE!"

--- a/bin/distro/ubuntu/start
+++ b/bin/distro/ubuntu/start
@@ -1,21 +1,7 @@
 #!/bin/bash
 
 export DOCKER_VERSION="17.03.2"
-
-### Declare colors to use during the running of this script:
-declare -r GREEN="\033[0;32m"
-declare -r RED="\033[0;31m"
-declare -r YELLOW="\033[0;33m"
-
-function echo_green {
-  echo -e "${GREEN}$1"; tput sgr0
-}
-function echo_red {
-  echo -e "${RED}$1"; tput sgr0
-}
-function echo_yellow {
-  echo -e "${YELLOW}$1"; tput sgr0
-}
+export DOCKER_PRVUSER="true"
 
 sudo apt-get update && sudo apt-get upgrade -y
 
@@ -43,4 +29,12 @@ sudo apt-get update
 
 sudo apt-get install -y docker-ce=${DOCKER_VERSION}~ce-0~ubuntu-xenial
 
-echo_green "\nCOMPLETE!"
+# Adding current ${USER} to docker group:
+if [ ${DOCKER_PRVUSER} != "true" ]
+then
+    echo "User "${USER}" will NOT be added to the docker group on ${HOSTNAME}"
+else
+    echo "Adding user "${USER}" to docker group on ${HOSTNAME}:"
+fi
+
+echo "COMPLETE!"

--- a/gantry
+++ b/gantry
@@ -29,7 +29,7 @@ function optionDistro () {
     elif [[ $VERSION_DISTRO == "ubuntu" || $VERSION_DISTRO == "debian" || $VERSION_DISTRO == "fedora" || $VERSION_DISTRO == "centos" ]]; then
         echo "[gantry] Distro declared is "$VERSION_DISTRO". This is an mutable distro."
         echo "[gantry] Ensure that the kubelet.service is stopped."
-            systemctl stop kubelet.service
+            systemctl stop kubelet
         echo "[gantry] Removing any stale artifacts from previous deployments."
             rm -rf /etc/systemd/system/multi-user.target.wants/*
             rm -rf /lib/systemd/system/kubelet.service
@@ -50,7 +50,9 @@ function optionDistro () {
             cp /opt/${ROOTFS}/etc/systemd/kubelet/kubelet.out /etc/systemd/system/kubelet.service
         echo "[gantry] Reloading systemd, and restarting the kubelet.service."
             systemctl daemon-reload
-            systemctl restart kubelet.service
+            systemctl restart kubelet
+            systemctl enable kubelet
+            systemctl enable docker
     else
         echo "Please choose a supported distro!"
     fi


### PR DESCRIPTION
* no more warnings for docker/kubelet not being enabled
* resolved RH distro errors for missing libgcrypt11 (currently testing in CentOS)
* optionally adding users to docker group for CentOS/Ubuntu
* place kubeadm requirements (socat and eventually cri-o) on separate layer